### PR TITLE
Add new enforced rubocop rules

### DIFF
--- a/rubocop/base/.rubocop.yml
+++ b/rubocop/base/.rubocop.yml
@@ -47,6 +47,12 @@ Metrics/ModuleLength:
     - '**/factories/**/*'
     - '**/config/routes.rb'
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent
+
 Layout/DotPosition:
    EnforcedStyle: trailing
 


### PR DESCRIPTION
### Overview
Enforces a consistent argument indentation (multiline-only) style across all projects by adding two RuboCop layout cops.

**Layout/ArgumentAlignment: with_fixed_indentation**
Arguments are indented by 2 spaces relative to the method call, instead of aligning with the first argument.

```ruby
# Before:
create(:job_ad,
       title: 'Job Ad Title',
       description: 'Sample desc')

JobAdService.new(company_id: company.id,
                 user_id: user.id,
                 status: :active)

# After:
create(
  :job_ad,
  title: 'Job Ad Title',
  description: 'Sample desc'
)

JobAdService.new(
  company_id: company.id,
  user_id: user.id,
  status: :active
)
```

**Layout/FirstArgumentIndentation: consistent**
Ensures the first argument on a new line follows the same fixed indentation, rather than aligning with the opening parenthesis.

```ruby
# Before:
render(
      :show,
      locals: { user: user }
)

# After:
render(
  :show,
  locals: { user: user }
)

# This avoids deep, fragile indentation that shifts whenever a method or variable is renamed.
```