### PR TITLE
rubocop: promote common Rails-project exclusions into the shared base

### DIFF
--- a/rubocop/base/.rubocop.disabled.yml
+++ b/rubocop/base/.rubocop.disabled.yml
@@ -17,3 +17,29 @@ Bundler/GemComment:
 
 Rails/SkipsModelValidations:
   Enabled: false
+
+# RSpec describe/context blocks, db migration `change` blocks, and environment
+# configurators naturally run long. Every Rails project in the monorepo excludes
+# these paths — promoting from per-project overrides into the shared base.
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+    - db/migrate/**/*
+    - config/environments/*.rb
+    - config/initializers/*.rb
+
+Metrics/MethodLength:
+  Exclude:
+    - db/migrate/**/*
+
+Metrics/AbcSize:
+  Exclude:
+    - db/migrate/**/*
+
+# rails_helper.rb is the Rails scaffold — keep the stock abort/exit/I18n pattern.
+Rails/Exit:
+  Exclude:
+    - spec/rails_helper.rb
+Rails/I18nLocaleAssignment:
+  Exclude:
+    - spec/rails_helper.rb


### PR DESCRIPTION
## Summary

Every Rails service in the yousty monorepo carries the same local `.rubocop.disabled.yml` overrides for specs, migrations, environment configs, initializers, and rails_helper.rb. This PR moves them into the shared qa-tools base so those services can drop their duplicate per-project blocks.

**Added exclusions:**

- `Metrics/BlockLength` — `spec/**/*`, `db/migrate/**/*`, `config/environments/*.rb`, `config/initializers/*.rb` (RSpec describe/context blocks, migration `change` blocks, and env/initializer configurators all run long by nature)
- `Metrics/MethodLength` / `Metrics/AbcSize` — `db/migrate/**/*`
- `Rails/Exit` / `Rails/I18nLocaleAssignment` — `spec/rails_helper.rb` (stock Rails scaffold)

## Impact

Services that inherit from this base will get these exclusions automatically on next rubocop cache refresh (~24h URL TTL or manual cache bust). Cleanup of the duplicate project-level blocks can follow in per-service PRs.

## Test plan

- [ ] Once merged, bust rubocop cache on `application_management_system` and verify its current `.rubocop.disabled.yml` becomes removable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)