### PR TITLE
rubocop: prefix Exclude globs with **/ so URL-inherited configs match

### DIFF
--- a/rubocop/base/.rubocop.disabled.yml
+++ b/rubocop/base/.rubocop.disabled.yml
@@ -23,23 +23,23 @@ Rails/SkipsModelValidations:
 # these paths — promoting from per-project overrides into the shared base.
 Metrics/BlockLength:
   Exclude:
-    - spec/**/*
-    - db/migrate/**/*
-    - config/environments/*.rb
-    - config/initializers/*.rb
+    - "**/spec/**/*"
+    - "**/db/migrate/**/*"
+    - "**/config/environments/*.rb"
+    - "**/config/initializers/*.rb"
 
 Metrics/MethodLength:
   Exclude:
-    - db/migrate/**/*
+    - "**/db/migrate/**/*"
 
 Metrics/AbcSize:
   Exclude:
-    - db/migrate/**/*
+    - "**/db/migrate/**/*"
 
 # rails_helper.rb is the Rails scaffold — keep the stock abort/exit/I18n pattern.
 Rails/Exit:
   Exclude:
-    - spec/rails_helper.rb
+    - "**/spec/rails_helper.rb"
 Rails/I18nLocaleAssignment:
   Exclude:
-    - spec/rails_helper.rb
+    - "**/spec/rails_helper.rb"


### PR DESCRIPTION
Follow-up to #3 — relative Exclude paths in a URL-inherited config resolve against rubocop's cache dir, not the consuming project, so they never matched real files. Prefix with `**/` like the rest of qa-tools' base already does.