### PR TITLE
rubocop: consolidate Metrics/Rails excludes into base .rubocop.yml

### DIFF
--- a/rubocop/base/.rubocop.disabled.yml
+++ b/rubocop/base/.rubocop.disabled.yml
@@ -17,29 +17,3 @@ Bundler/GemComment:
 
 Rails/SkipsModelValidations:
   Enabled: false
-
-# RSpec describe/context blocks, db migration `change` blocks, and environment
-# configurators naturally run long. Every Rails project in the monorepo excludes
-# these paths — promoting from per-project overrides into the shared base.
-Metrics/BlockLength:
-  Exclude:
-    - "**/spec/**/*"
-    - "**/db/migrate/**/*"
-    - "**/config/environments/*.rb"
-    - "**/config/initializers/*.rb"
-
-Metrics/MethodLength:
-  Exclude:
-    - "**/db/migrate/**/*"
-
-Metrics/AbcSize:
-  Exclude:
-    - "**/db/migrate/**/*"
-
-# rails_helper.rb is the Rails scaffold — keep the stock abort/exit/I18n pattern.
-Rails/Exit:
-  Exclude:
-    - "**/spec/rails_helper.rb"
-Rails/I18nLocaleAssignment:
-  Exclude:
-    - "**/spec/rails_helper.rb"

--- a/rubocop/base/.rubocop.yml
+++ b/rubocop/base/.rubocop.yml
@@ -33,6 +33,20 @@ Layout/LineLength:
 
 Metrics/MethodLength:
   Max: 20
+  Exclude:
+    - '**/db/migrate/**/*'
+
+Metrics/AbcSize:
+  Exclude:
+    - '**/db/migrate/**/*'
+
+Rails/Exit:
+  Exclude:
+    - '**/spec/rails_helper.rb'
+
+Rails/I18nLocaleAssignment:
+  Exclude:
+    - '**/spec/rails_helper.rb'
 
 Metrics/BlockLength:
   Exclude:
@@ -40,6 +54,9 @@ Metrics/BlockLength:
     - '**/factories/**/*'
     - '**/config/routes.rb'
     - '**/tasks/eventstore.rake'
+    - '**/db/migrate/**/*'
+    - '**/config/environments/*.rb'
+    - '**/config/initializers/*.rb'
 
 Metrics/ModuleLength:
   Exclude:


### PR DESCRIPTION
Follow-up to #3 and #4. Fixes the Exclude-merge + cache-anchoring interaction by putting all new exclusions in base .rubocop.yml where they extend the existing Metrics/BlockLength block (avoids the child-replaces-parent issue).